### PR TITLE
Add support of .js and .json

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 var readline = require('readline');
 var rl = readline.createInterface({
   input: process.stdin,
@@ -9,24 +10,68 @@ var sailsConfigFileName;
 // preset code style
 var preset = null;
 
-var updateEslintrc = function(err, data) {
+var readFile = function(fileName, cb) {
+  console.log('./' + fileName)
+  switch (path.extname(fileName)) {
+    case '':
+      try {
+        var config = JSON.parse(fs.readFileSync(fileName, 'utf-8'));
+        cb(null, config);
+      } catch (err) {
+        cb(err);
+      }
+      break;
+    case '.js':
+    case '.json':
+      try {
+        var eslintConfig = require('/' + process.cwd() + '/' + fileName);
+        cb(null, eslintConfig);
+      } catch (err) {
+        console.trace(err);
+        cb(err);
+      }
+      break;
+    default:
+      console.error('readFile: Can\'t found the eslintrc file.');
+  }
+};
+
+var writeFile = function(fileName, data) {
+  switch (path.extname(fileName)) {
+    case '':
+    case '.json':
+      fs.writeFileSync(eslintConfigFileName, data);
+      break;
+    case '.js':
+      fs.writeFileSync(eslintConfigFileName, 'module.exports = ' + data);
+      break;
+    default:
+      console.error('writeFile: Can\'t found the eslintrc file.');
+  }
+};
+
+var updateEslintrc = function(err, config) {
   if (err) {
     console.log('readFile return error:');
     console.log(err);
   } else {
     // console.log(data);
-    var config = JSON.parse(data);
     // config.globals = _.extend(config.globals, globals);
     if (config.extends.indexOf(sailsConfigFileName) >= 0) {
       console.log('add ' + sailsConfigFileName);
       return;
     }
+
+    // If config.extends is not Array, change it to Array.
+    if (!Array.isArray(config.extends))
+      config.extends = [config.extends];
+
     if (preset && config.extends.indexOf(preset) < 0) {
       config.extends = config.extends.concat(preset);
     }
     config.extends = config.extends.concat(sailsConfigFileName);
     // console.log(config);
-    fs.writeFileSync(eslintConfigFileName, JSON.stringify(config, null, '\t'));
+    writeFile(eslintConfigFileName, JSON.stringify(config, null, '\t'));
     console.log('add ' + sailsConfigFileName +
       ' and modify ' + eslintConfigFileName);
   }
@@ -34,7 +79,9 @@ var updateEslintrc = function(err, data) {
 
 var establishEslintrc = function(answer) {
   switch (answer.trim()) {
-    case 'yes': case 'y': case 'Y':
+    case 'yes':
+    case 'y':
+    case 'Y':
       fs.open(eslintConfigFileName, 'w', function(err) {
         if (err) {
           console.log(err);
@@ -49,7 +96,9 @@ var establishEslintrc = function(answer) {
           }, null, '\t'));
       });
       break;
-    case 'no': case 'n': case 'N':
+    case 'no':
+    case 'n':
+    case 'N':
       console.log('Please establish ' + eslintConfigFileName + ' first!');
       break;
     default:
@@ -65,7 +114,7 @@ exports.configureEslintrc = function(eFileName, sFileName, presetCodeStyle) {
   preset = presetCodeStyle;
   fs.exists(eslintConfigFileName, function(exists) {
     if (exists) {
-      fs.readFile(eslintConfigFileName, 'utf-8', updateEslintrc);
+      readFile(eslintConfigFileName, updateEslintrc);
       rl.close();
     } else {
       console.log(eslintConfigFileName + ' is not exists!');

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -43,13 +43,13 @@ exports.appendConfigFile = function(globals, sailsConfigFileName) {
       }
     } else {
       console.log(sailsConfigFileName +
-        'is not exists, it will be created');
+        ' is not exists, it will be created');
       fs.open(sailsConfigFileName, 'w', function(err) {
         if (err) {
           console.log('error:' + err);
           process.exit(0);
         }
-        console.log(sailsConfigFileName + 'is created!');
+        console.log(sailsConfigFileName + ' is created!');
       });
       eslintrcSails.globals = globals;
     }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "commander": "^2.9.0",
     "eslint": "^1.10.3",
     "eslint-config-google": "^0.3.0",
+    "fs-finder": "^1.8.1",
     "underscore": "^1.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-generate-eslintrc",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "generate eslint config file which contains sails's globals",
   "main": "index.js",
   "bin": "./index.js",


### PR DESCRIPTION
resolved #1 
1. support .eslintrc.js and .eslintrc.json. In default, will find .eslintrc first.
2. fix bug: .eslintrc extends property can be String or Array. This PR support String type of "extends". It's will auto change to Array.

PS. Oops! Maybe you need to decide the version. This PR is bump to 1.4.0.