### PR TITLE
patch for filename

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -24,7 +24,7 @@ var readFile = function(fileName, cb) {
     case '.js':
     case '.json':
       try {
-        var eslintConfig = require('/' + process.cwd() + '/' + fileName);
+        var eslintConfig = require(fileName);
         cb(null, eslintConfig);
       } catch (err) {
         console.trace(err);


### PR DESCRIPTION
I got this error so after checking the filename path I saw that it is already in full path format
```
Use /home/dan/project/application/builder/src/api/.eslintrc.js as eslintrc file.
.//home/dan/project/application/builder/src/api/.eslintrc.js
Trace: { Error: Cannot find module '//home/dan/project/application/builder/src/api//home/dan/project/application/builder/src/api/.eslintrc.js'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at readFile (/home/dan/project/application/builder/src/api/node_modules/sails-generate-eslintrc/lib/configure.js:27:28)
    at /home/dan/project/application/builder/src/api/node_modules/sails-generate-eslintrc/lib/configure.js:117:7
    at FSReqWrap.cb [as oncomplete] (fs.js:258:19) code: 'MODULE_NOT_FOUND' }
    at readFile (/home/dan/project/application/builder/src/api/node_modules/sails-generate-eslintrc/lib/configure.js:30:17)
    at /home/dan/project/application/builder/src/api/node_modules/sails-generate-eslintrc/lib/configure.js:117:7
    at FSReqWrap.cb [as oncomplete] (fs.js:258:19)
readFile return error:
{ Error: Cannot find module '//home/dan/project/application/builder/src/api//home/dan/project/application/builder/src/api/.eslintrc.js'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at readFile (/home/dan/project/application/builder/src/api/node_modules/sails-generate-eslintrc/lib/configure.js:27:28)
    at /home/dan/project/application/builder/src/api/node_modules/sails-generate-eslintrc/lib/configure.js:117:7
    at FSReqWrap.cb [as oncomplete] (fs.js:258:19) code: 'MODULE_NOT_FOUND' }
```